### PR TITLE
Add GitHub issue form templates for feature, bug, and infra

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,102 @@
+name: Bug Report
+description: Report a defect impacting expected behavior.
+title: "[Bug]: "
+labels:
+  - bug
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Provide reproducible details. Include tenant/subdomain context when relevant.
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Select the area where the defect occurs.
+      options:
+        - Scheduling
+        - Visualizer
+        - Billing & Stripe
+        - Auth & RBAC
+        - Tenant & Subdomain Routing
+        - Notifications
+        - Integrations
+        - Admin & Backoffice
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the operational/business severity.
+      options:
+        - S1 - Critical (outage/data loss/security)
+        - S2 - High (core workflow degraded)
+        - S3 - Medium (workaround exists)
+        - S4 - Low (minor defect)
+    validations:
+      required: true
+
+  - type: input
+    id: tenant_context
+    attributes:
+      label: Tenant/Subdomain Context
+      description: Which tenant subdomain(s) are affected?
+      placeholder: e.g. acme.example.com
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction Steps
+      description: List deterministic steps to reproduce.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: architecture_gates
+    attributes:
+      label: Architecture & Security Checks
+      description: Validate platform invariants while triaging.
+      options:
+        - label: Bug is not caused by bypassing tenant isolation (tenant resolved server-side).
+          required: true
+        - label: Authorization failure/success has been verified server-side (not only client state).
+          required: true
+        - label: Any mutation path involved uses server actions with input validation.
+          required: true
+        - label: Logs shared here do not contain secrets or sensitive personal data.
+          required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs / Stack Traces / Evidence
+      description: Include relevant snippets and monitoring links.
+
+  - type: input
+    id: regression
+    attributes:
+      label: Regression?
+      description: First known version/commit where this started (if known).
+      placeholder: e.g. v1.24.0 or commit SHA

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,89 @@
+name: Feature Request
+description: Propose a new product capability or a meaningful enhancement.
+title: "[Feature]: "
+labels:
+  - feature
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for product/domain features. Include expected behavior, user impact, and architectural constraints.
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Select the primary business/domain area.
+      options:
+        - Scheduling
+        - Visualizer
+        - Billing & Stripe
+        - Auth & RBAC
+        - Tenant & Subdomain Routing
+        - Notifications
+        - Integrations
+        - Admin & Backoffice
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What user or business problem should this solve?
+      placeholder: Describe the current limitation and affected users/workflows.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the desired behavior and key acceptance criteria.
+      placeholder: Include happy path, edge cases, and expected outcomes.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity / Business Impact
+      description: Estimate business urgency and impact.
+      options:
+        - S4 - Low (nice-to-have)
+        - S3 - Medium (important improvement)
+        - S2 - High (material user/business impact)
+        - S1 - Critical (blocks core workflow or revenue)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: architecture_gates
+    attributes:
+      label: Architecture & Security Gates
+      description: Confirm required platform constraints are understood.
+      options:
+        - label: No Prisma usage in app/ routes/components; data access goes through fetchers/actions.
+          required: true
+        - label: Tenant scope is resolved server-side from host/subdomain (never from client-provided tenantId).
+          required: true
+        - label: Authorization is enforced server-side with explicit permission checks.
+          required: true
+        - label: Inputs for mutations are validated with Zod in server actions.
+          required: true
+        - label: Tests will be added/updated (unit/integration/e2e as appropriate).
+          required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals / Out of Scope
+      description: Clarify what this request should not include.
+      placeholder: List boundaries to avoid scope creep.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Links, screenshots, customer notes, or related issues.

--- a/.github/ISSUE_TEMPLATE/infra.yml
+++ b/.github/ISSUE_TEMPLATE/infra.yml
@@ -1,0 +1,99 @@
+name: Infrastructure Request / Incident
+description: Track infrastructure, platform, reliability, or operations work.
+title: "[Infra]: "
+labels:
+  - infra
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for reliability, deployment, environment, and platform changes/incidents.
+
+  - type: dropdown
+    id: infra_scope
+    attributes:
+      label: Infrastructure Scope
+      description: Select the primary scope.
+      options:
+        - CI/CD Pipelines
+        - Build System & Dependencies
+        - Runtime Platform & Hosting
+        - Database & Migrations
+        - Caching & Performance
+        - Networking, DNS & Subdomains
+        - Security, Secrets & IAM
+        - Observability, Logging & Alerting
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Operational severity/urgency.
+      options:
+        - Sev-1 (production outage/security emergency)
+        - Sev-2 (major degradation)
+        - Sev-3 (moderate impact)
+        - Sev-4 (low impact / planned work)
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the request or incident.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Who/what is impacted (tenants, systems, revenue, delivery)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_changes
+    attributes:
+      label: Proposed Changes / Mitigation Plan
+      description: What change should be made, or what mitigation is required?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: architecture_gates
+    attributes:
+      label: Architecture & Security Gates
+      description: Confirm constraints before implementation.
+      options:
+        - label: Tenant isolation and host/subdomain-based tenant resolution remain enforced server-side.
+          required: true
+        - label: No business mutation path is moved outside approved server action boundaries.
+          required: true
+        - label: Secrets/tokens are managed via secure runtime configuration (not committed or logged).
+          required: true
+        - label: Observability updates include actionable metrics/logs/alerts without exposing sensitive data.
+          required: true
+
+  - type: input
+    id: change_window
+    attributes:
+      label: Requested Change Window
+      description: Planned rollout window and timezone.
+      placeholder: e.g. 2026-03-12 22:00-23:00 UTC
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback / Contingency Plan
+      description: Describe rollback strategy or immediate recovery actions.
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link dashboards, runbooks, incident docs, or related issues.


### PR DESCRIPTION
### Motivation
- Standardize issue intake for product, bug, and infrastructure work and encode platform constraints (domain, severity, and architecture/security gates) in the issue forms.
- Ensure contributors explicitly acknowledge tenant, authz, and testing requirements enforced by the platform architecture before work begins.

### Description
- Add ` .github/ISSUE_TEMPLATE/feature.yml` which includes domain dropdown, severity, structured `problem`/`proposal` fields, and architecture/security gate checkboxes that mirror repository conventions.
- Add ` .github/ISSUE_TEMPLATE/bug.yml` which includes domain and severity dropdowns, tenant/subdomain context, reproducible steps, expected/actual fields, and triage checkboxes for tenant isolation and server-side authorization.
- Add ` .github/ISSUE_TEMPLATE/infra.yml` which includes `infra_scope` and severity dropdowns, impact/mitigation/rollback fields, and architecture/security gate checkboxes for secrets and observability constraints.
- No application runtime code or architectural boundaries were modified; these are metadata-only additions to guide contributors.

### Testing
- Validated YAML parsing of all three files using Ruby: `ruby -e 'require "yaml"; %w[.github/ISSUE_TEMPLATE/feature.yml .github/ISSUE_TEMPLATE/bug.yml .github/ISSUE_TEMPLATE/infra.yml].each{|f| YAML.load_file(f); puts "ok #{f}"}'`, and the loader returned `ok` for each file.
- Committed the new files and confirmed they are present in the diff; no automated unit/integration tests were required for metadata-only files and none were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936705b71883278643ec7f5ee73223)