### PR TITLE
DEMO-003: remove Clerk org-context dependency from tenant RBAC

### DIFF
--- a/app/(tenant)/admin/page.tsx
+++ b/app/(tenant)/admin/page.tsx
@@ -25,7 +25,6 @@ export default async function AdminDashboardPage() {
   await requirePermission({
     headers: headerMap,
     tenantId: tenant.tenantId,
-    tenantClerkOrgId: tenant.clerkOrgId,
     permission: 'admin:read'
   });
 

--- a/lib/actions/catalog/create-wrap-design.ts
+++ b/lib/actions/catalog/create-wrap-design.ts
@@ -18,7 +18,6 @@ export async function createWrapDesign(input: CreateWrapDesignActionInput): Prom
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'catalog:write'
   });
 

--- a/lib/actions/catalog/delete-wrap-design.ts
+++ b/lib/actions/catalog/delete-wrap-design.ts
@@ -18,7 +18,6 @@ export async function deleteWrapDesign(input: DeleteWrapDesignActionInput): Prom
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'catalog:write'
   });
 

--- a/lib/actions/catalog/update-wrap-design.ts
+++ b/lib/actions/catalog/update-wrap-design.ts
@@ -18,7 +18,6 @@ export async function updateWrapDesign(input: UpdateWrapDesignActionInput): Prom
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'catalog:write'
   });
 

--- a/lib/actions/create-booking.ts
+++ b/lib/actions/create-booking.ts
@@ -34,7 +34,6 @@ export async function createBooking(input: CreateBookingActionInput): Promise<Bo
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'schedule:write'
   });
 

--- a/lib/actions/create-checkout-session.ts
+++ b/lib/actions/create-checkout-session.ts
@@ -32,7 +32,6 @@ export async function createCheckoutSession(input: CreateCheckoutSessionInput): 
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'billing:write'
   });
 

--- a/lib/actions/create-invoice.ts
+++ b/lib/actions/create-invoice.ts
@@ -34,7 +34,6 @@ export async function createInvoice(input: CreateInvoiceInput): Promise<InvoiceR
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'billing:write'
   });
 

--- a/lib/actions/create-template-preview.ts
+++ b/lib/actions/create-template-preview.ts
@@ -24,7 +24,6 @@ export async function createTemplatePreviewAction(
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'catalog:read'
   });
 

--- a/lib/actions/create-upload-preview.ts
+++ b/lib/actions/create-upload-preview.ts
@@ -30,7 +30,6 @@ export async function createUploadPreviewAction(
   const permissionContext = await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'catalog:write'
   });
 

--- a/lib/auth/require-permission.ts
+++ b/lib/auth/require-permission.ts
@@ -15,7 +15,6 @@ export class PermissionError extends Error {
 export interface RequirePermissionInput {
   readonly headers: Readonly<Record<string, string | undefined>>;
   readonly tenantId: string;
-  readonly tenantClerkOrgId: string;
   readonly permission: Permission;
 }
 
@@ -32,8 +31,6 @@ export async function requirePermission(input: RequirePermissionInput): Promise<
 
   const role = resolveTenantRole({
     tenantId: input.tenantId,
-    tenantClerkOrgId: input.tenantClerkOrgId,
-    activeOrgId: user.orgId,
     actorUserId: user.userId,
     privateMetadata: user.privateMetadata
   });

--- a/lib/fetchers/get-invoice.ts
+++ b/lib/fetchers/get-invoice.ts
@@ -121,7 +121,6 @@ export async function getInvoice(input: GetInvoiceInput): Promise<InvoiceRecord>
   await requirePermission({
     headers: input.headers,
     tenantId,
-    tenantClerkOrgId: tenantContext.tenant.clerkOrgId,
     permission: 'billing:read'
   });
 


### PR DESCRIPTION
### Motivation
- Remove reliance on Clerk "active org"/org-scoped roles for authorization so tenant RBAC is derived from server-trusted tenant scope and actor identity.
- Ensure tenant isolation remains authoritative (tenant resolved from host/subdomain) and that permission gates remain enforced server-side.
- This change addresses the behavior described in issue #54 and intends to close it (Closes #54).

### Description
- Remove `tenantClerkOrgId` / `activeOrgId` checks and `orgRoles` fallback from the authorization path by changing `resolveTenantRole` to consult only tenant-scoped `tenantRoles` metadata and configured tenant role bindings.
- Update `requirePermission` to call `resolveTenantRole` with only `(tenantId, actorUserId, privateMetadata)` and throw when no tenant membership is found.
- Stop passing Clerk org identifiers to permission-gated call sites and keep tenant resolution server-side; updated callers include actions/fetchers/pages such as `create-*` actions, `getInvoice`, and the admin page.
- Add regression coverage to `tests/unit/rbac.test.ts` for: valid tenant membership (without org context), missing membership denial, and cross-tenant denial even when the user has membership in another tenant; leave a follow-up note to align production Clerk metadata provisioning if required.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm typecheck` (`tsc --noEmit`) and it completed successfully.
- Ran unit and integration tests with `pnpm test` and all test suites passed (49 tests passed across unit/integration files).
- Ran e2e with `pnpm test:e2e` and the existing happy-path spec passed (1 e2e test passed).
- New/updated tests: `tests/unit/rbac.test.ts` (adds membership/missing/cross-tenant regression cases) and all tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2d04ed208327aea34cfcc777fc82)