### PR TITLE
docs: add DEMO-008 deployment runbook and demo release checklist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,11 @@
 # Pull current values from Vercel with:
 #   pnpm dlx vercel env pull .env.local --environment development
 
-# Clerk values from Vercel
+# Required: Clerk values from Vercel
 AUTH_CLERK_SECRET_KEY=""
 NEXT_PUBLIC_AUTH_CLERK_PUBLISHABLE_KEY=""
 
-# Canonical Clerk aliases for local tooling and MCP clients
+# Required aliases: canonical Clerk names used by tooling and MCP clients
 CLERK_SECRET_KEY="$AUTH_CLERK_SECRET_KEY"
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$NEXT_PUBLIC_AUTH_CLERK_PUBLISHABLE_KEY"
 
@@ -14,7 +14,7 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$NEXT_PUBLIC_AUTH_CLERK_PUBLISHABLE_KEY"
 NEXT_PUBLIC_CLERK_FRONTEND_API_URL=""
 NEXT_PUBLIC_AUTH_CLERK_FRONTEND_API_URL=""
 
-# Neon/Postgres
+# Required: Neon/Postgres
 DATABASE_URL=""
 DATABASE_URL_UNPOOLED=""
 
@@ -23,5 +23,7 @@ NEON_API_KEY=""
 
 # Optional app/runtime variables
 AUTH_TENANT_ROLE_BINDINGS=""
-STRIPE_WEBHOOK_SECRET=""
 VERCEL_OIDC_TOKEN=""
+
+# Required in deployed environments handling Stripe webhooks
+STRIPE_WEBHOOK_SECRET=""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Linked Issue
 
-- Closes #58
+- Closes #59
 
 ## Architecture / Security Checklist
 
@@ -14,9 +14,12 @@
 - [ ] Inputs for mutations are validated with Zod in server actions.
 - [ ] Validation failures return deterministic, safe action errors.
 - [ ] Structured logs include correlation IDs and explicit redaction for secrets/sensitive payloads.
+- [ ] Deployment runbook updated (migration, rollback, verification) when release behavior changed.
+- [ ] Environment contract updates are synchronized across `.env.example`, `README.md`, and docs.
 
 ## Testing
 
 - [ ] Unit tests added/updated.
 - [ ] Integration tests added/updated.
 - [ ] E2E tests added/updated (if user flow changed).
+- [ ] Targeted release verification commands documented/executed for affected flows.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ This repository now includes baseline engineering and GitHub automation scaffold
    pnpm dlx vercel env pull .env.local --environment development
    ```
 
-4. Run baseline quality checks:
+4. Runtime environment contract (from `.env.example`) for local and deployed environments:
+
+   - `AUTH_CLERK_SECRET_KEY`
+   - `NEXT_PUBLIC_AUTH_CLERK_PUBLISHABLE_KEY`
+   - `CLERK_SECRET_KEY` (alias)
+   - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (alias)
+   - `NEXT_PUBLIC_CLERK_FRONTEND_API_URL` (optional)
+   - `NEXT_PUBLIC_AUTH_CLERK_FRONTEND_API_URL` (optional)
+   - `DATABASE_URL`
+   - `DATABASE_URL_UNPOOLED`
+   - `NEON_API_KEY` (optional for MCP/API workflows)
+   - `AUTH_TENANT_ROLE_BINDINGS` (optional, non-production mappings)
+   - `STRIPE_WEBHOOK_SECRET`
+   - `VERCEL_OIDC_TOKEN` (optional)
+
+5. Run baseline quality checks:
 
    ```bash
    pnpm lint
@@ -36,7 +51,7 @@ This repository now includes baseline engineering and GitHub automation scaffold
    pnpm test
    ```
 
-5. Start the Next.js app locally:
+6. Start the Next.js app locally:
 
    ```bash
    pnpm dev
@@ -53,4 +68,6 @@ pnpm bootstrap:github
 This syncs labels, milestones, roadmap issues, and project board field metadata.
 
 See `docs/github-workflow.md` and `docs/ci-design.md` for governance details.
+Use `docs/deployment-runbook.md` for migration/rollback/verification deployment steps.
+Use `docs/demo-release-checklist.md` for demo release readiness checks.
 Use `docs/README.md` for the documentation index and report locations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ This directory contains project guidance and report snapshots.
 - `docs/github-workflow.md`: labels, roadmap sync, and governance bootstrap.
 - `docs/ci-design.md`: CI quality gates and flaky-test handling policy.
 - `docs/pr-checklist.md`: merge checklist used by pull requests.
+- `docs/deployment-runbook.md`: deployment sequence, migration safety, rollback, and verification flow.
+- `docs/demo-release-checklist.md`: M9 demo release readiness checklist.
 
 ## Design system docs
 

--- a/docs/demo-release-checklist.md
+++ b/docs/demo-release-checklist.md
@@ -1,0 +1,38 @@
+# Demo Release Checklist (M9)
+
+Use this checklist before cutting a demo release so documentation, governance, and runtime expectations remain in sync.
+
+## 1) Scope and governance
+
+- [ ] Milestone scope matches `.github/task-manifest.json` and linked issues.
+- [ ] PR body uses template sections and includes `Closes #...` references.
+- [ ] PR checklist items are complete in `.github/pull_request_template.md`.
+- [ ] Dependencies called out in milestone notes are merged.
+
+## 2) Environment and secrets
+
+- [ ] `.env.example`, `README.md`, and `docs/deployment-runbook.md` list the same env contract.
+- [ ] Clerk keys are configured for target environment.
+- [ ] Neon database URLs are configured (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`).
+- [ ] `STRIPE_WEBHOOK_SECRET` is configured in deployed environment.
+
+## 3) Build, quality, and verification
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm test tests/integration/stripe-webhook.test.ts`
+- [ ] `pnpm test tests/integration/prisma-tenancy.test.ts`
+- [ ] `pnpm test:e2e tests/e2e/auth-routing-regression.spec.ts`
+
+## 4) Deployment safety
+
+- [ ] Migration plan reviewed and `pnpm dlx prisma migrate deploy` prepared.
+- [ ] Rollback owner and compensating migration strategy documented.
+- [ ] Post-deploy smoke checks assigned (tenant routing + checkout flow).
+
+## 5) Release closeout
+
+- [ ] Deployment outcomes and follow-ups are logged in PR comments.
+- [ ] Any incidents include root cause and preventive tasks.
+- [ ] Release docs remain current with scripts in `package.json`.

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -1,0 +1,141 @@
+# Deployment Runbook (DEMO-008)
+
+This runbook defines the standard deployment flow for CtrlPlus with a focus on **safe migrations**, **rollback readiness**, and **post-deploy verification**.
+
+Use this runbook for staging and production releases so deployment behavior stays consistent with repository governance and CI quality gates.
+
+## 1) Preconditions
+
+Before any deployment:
+
+1. Main branch is green for required CI checks.
+2. PR checklist is complete (`docs/pr-checklist.md`).
+3. The release operator has access to:
+   - Vercel project and environment variables.
+   - Neon database branch/role used by production.
+   - Stripe webhook configuration for the target environment.
+4. `gh` CLI is installed and authenticated for governance workflows.
+
+## 2) Environment contract
+
+The following variables are the canonical runtime contract and must stay aligned across `.env.example`, `README.md`, and this runbook.
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `AUTH_CLERK_SECRET_KEY` | Yes | Clerk backend secret used by server auth helpers. |
+| `NEXT_PUBLIC_AUTH_CLERK_PUBLISHABLE_KEY` | Yes | Clerk publishable key for browser auth flows. |
+| `CLERK_SECRET_KEY` | Yes (alias) | Canonical alias for tooling expecting default Clerk naming. |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes (alias) | Canonical alias for tooling expecting default Clerk naming. |
+| `NEXT_PUBLIC_CLERK_FRONTEND_API_URL` | Optional | Explicit Clerk frontend API origin override. |
+| `NEXT_PUBLIC_AUTH_CLERK_FRONTEND_API_URL` | Optional | Backward-compatible frontend API origin alias. |
+| `DATABASE_URL` | Yes | Prisma pooled connection string for app queries. |
+| `DATABASE_URL_UNPOOLED` | Yes | Prisma direct connection string for migrations. |
+| `NEON_API_KEY` | Optional | Neon API key for MCP/API workflows (not required at runtime). |
+| `AUTH_TENANT_ROLE_BINDINGS` | Optional | Static tenant-role binding map for local/non-production workflows. |
+| `STRIPE_WEBHOOK_SECRET` | Yes in deployed envs | Stripe webhook signature secret. |
+| `VERCEL_OIDC_TOKEN` | Optional | OIDC token when using Vercel identity integrations. |
+
+## 3) Standard deployment sequence
+
+### Step A: Sync and verify candidate commit
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+### Step B: Apply migrations safely
+
+Use production-scoped environment values before running commands.
+
+```bash
+pnpm dlx prisma migrate deploy
+```
+
+Migration policy:
+
+- Use forward-only migrations in `prisma/migrations/**`.
+- Avoid destructive schema changes without an explicit backfill and rollback strategy.
+- Confirm migration history after deploy:
+
+```bash
+pnpm dlx prisma migrate status
+```
+
+### Step C: Trigger deployment
+
+Deploy via the GitHub->Vercel integration from main after migrations pass.
+
+If a manual deploy is required:
+
+```bash
+pnpm dlx vercel deploy --prod
+```
+
+## 4) Post-deploy verification
+
+Run these checks immediately after deployment.
+
+### 4.1 Static quality gates (local/CI)
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+### 4.2 Targeted runtime verification
+
+```bash
+pnpm test tests/integration/stripe-webhook.test.ts
+pnpm test tests/integration/prisma-tenancy.test.ts
+pnpm test:e2e tests/e2e/auth-routing-regression.spec.ts
+```
+
+Verification expectations:
+
+- Stripe webhook signature and idempotency logic remains intact.
+- Tenant isolation queries reject cross-tenant access.
+- Auth route handling remains stable for sign-in/sign-up and tenant routing.
+
+### 4.3 Operational smoke checks
+
+- Confirm tenant subdomain routes resolve to the correct tenant context.
+- Validate one end-to-end checkout flow in the target environment.
+- Confirm no new high-severity alerts in deployment logs.
+
+## 5) Rollback procedure
+
+When release quality or production safety is in doubt, stop rollout and execute rollback.
+
+1. **Freeze additional deploys** and communicate incident status.
+2. **Revert application version** in Vercel to the previous known-good deployment.
+3. **Assess migration impact**:
+   - If migration is backward-compatible, keep schema and rollback app only.
+   - If migration introduced incompatible changes, execute a prepared compensating migration.
+4. **Re-run post-rollback verification**:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm test tests/integration/prisma-tenancy.test.ts
+```
+
+5. **Record incident notes** in PR/issue with root cause and preventive action items.
+
+## 6) Documentation and governance alignment
+
+For every release PR:
+
+- Include `Closes #<issue>` in the PR body.
+- Complete all checklist items in `.github/pull_request_template.md`.
+- Ensure release docs stay aligned with:
+  - `docs/github-workflow.md`
+  - `docs/ci-design.md`
+  - `docs/pr-checklist.md`

--- a/docs/pr-checklist.md
+++ b/docs/pr-checklist.md
@@ -17,3 +17,6 @@ Use this checklist for every PR.
 - [ ] Auth + permission validated server-side
 - [ ] Zod validation added (if input)
 - [ ] No `console.log`s
+- [ ] Deployment updates documented in `docs/deployment-runbook.md` (migration + rollback + verification)
+- [ ] Environment contract remains synchronized across `.env.example`, `README.md`, and deployment docs
+- [ ] Demo release criteria validated using `docs/demo-release-checklist.md` when applicable


### PR DESCRIPTION
### Motivation
- Provide an explicit deployment runbook for DEMO-008 that codifies migration, rollback, and post-deploy verification steps for staging/production releases.
- Make the environment variable contract authoritative and consistent across `.env.example`, `README.md`, and the docs so releases and local development share the same expectations.
- Supply an M9 demo release checklist to enforce governance, verification, and release-safety tasks before cutting demo releases.

### Description
- Added `docs/deployment-runbook.md` describing preconditions, standard deployment sequence, safe `prisma` migration steps, rollback procedure, and targeted post-deploy verification commands.
- Added `docs/demo-release-checklist.md` with a focused demo release checklist (scope, env/secrets, quality gates, deployment safety, and closeout).
- Updated `.env.example` and `README.md` to clarify required vs optional runtime variables and to reflect the canonical env contract used by the runbook.
- Updated documentation index (`docs/README.md`), standard PR checklist (`docs/pr-checklist.md`), and PR template (`.github/pull_request_template.md`) to include deployment/runbook items, env-consistency checks, and to default to closing the correct issue (`Closes #59`).

### Testing
- Ran `pnpm lint` which failed due to pre-existing TypeScript/ESLint issues in action modules unrelated to these docs-only changes.
- Ran `pnpm typecheck` which failed due to pre-existing missing `zod` resolution and typing issues in existing action modules unrelated to these docs-only changes.
- Ran `pnpm test` which reported multiple failing suites caused by missing `zod` module imports in existing code, while several existing tests passed (see targeted runs below).
- Targeted verification commands from the runbook: `pnpm test tests/integration/prisma-tenancy.test.ts` passed and `pnpm test:e2e tests/e2e/auth-routing-regression.spec.ts` passed, while `pnpm test tests/integration/stripe-webhook.test.ts` failed due to the same pre-existing `zod` resolution issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f35ba1f0883279996fa4a5cf95409)