### PR TITLE
[WIP] [DESIGN-001] Enforce global design tokens and Tailwind v4 contract

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -50,9 +50,7 @@ body {
 
 body {
   font-family: var(--font-primary);
-  background:
-    radial-gradient(circle at top, #183d75 0%, rgba(24, 61, 117, 0) 48%),
-    linear-gradient(180deg, #061229 0%, #07142b 55%, #09162d 100%);
+  background: var(--bg);
   color: var(--text);
   line-height: 1.6;
 }
@@ -91,9 +89,11 @@ main {
 
 h1,
 h2 {
-  font-family: 'Georgia', 'Times New Roman', serif;
-  letter-spacing: 0.01em;
-  line-height: 1.16;
+  font-family: var(--font-primary);
+  font-weight: 700;
+  letter-spacing: var(--tracking-headline);
+  line-height: 0.98;
+  text-transform: uppercase;
 }
 
 h1 {
@@ -183,7 +183,7 @@ p {
 }
 
 .brand__name {
-  font-family: 'Georgia', 'Times New Roman', serif;
+  font-family: var(--font-primary);
   font-size: 1.3rem;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -239,7 +239,7 @@ p {
   font-weight: 600;
   font-size: 0.92rem;
   line-height: 1;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
 .button:hover,
@@ -248,14 +248,14 @@ p {
 }
 
 .button--primary {
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  background: var(--accent);
+  border-color: var(--accent-strong);
   color: #f4f8ff;
-  box-shadow: 0 8px 20px rgba(43, 95, 255, 0.32);
 }
 
 .button--primary:hover,
 .button--primary:focus-visible {
-  box-shadow: 0 12px 22px rgba(43, 95, 255, 0.4);
+  background: var(--accent-strong);
 }
 
 .button--ghost {
@@ -459,7 +459,7 @@ p {
   border-radius: 1rem;
   overflow: hidden;
   border: 1px solid var(--border);
-  background: linear-gradient(170deg, rgba(20, 52, 106, 0.6), rgba(9, 19, 44, 0.95));
+  background: var(--surface-strong);
 }
 
 .media-card img {
@@ -490,7 +490,7 @@ p {
   position: absolute;
   inset: auto 0 0;
   padding: 0.75rem 0.85rem;
-  background: linear-gradient(180deg, rgba(6, 16, 35, 0), rgba(6, 16, 35, 0.85));
+  background: rgba(6, 16, 35, 0.85);
   color: #f2f5ff;
   font-size: 0.85rem;
 }
@@ -508,7 +508,7 @@ p {
 .card {
   border-radius: 1rem;
   border: 1px solid var(--border);
-  background: linear-gradient(180deg, rgba(16, 37, 74, 0.96), rgba(10, 24, 50, 0.96));
+  background: var(--surface);
 }
 
 .stat-card {
@@ -637,7 +637,7 @@ p {
   margin-top: 3.1rem;
   border-radius: 1rem;
   border: 1px solid rgba(124, 172, 255, 0.34);
-  background: linear-gradient(140deg, rgba(27, 61, 123, 0.78), rgba(12, 28, 58, 0.95));
+  background: var(--surface-strong);
   padding-block: 1.55rem;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;

--- a/tests/unit/design-tokens-contract.test.ts
+++ b/tests/unit/design-tokens-contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('design token and tailwind v4 contract', () => {
+  const projectRoot = resolve(__dirname, '../..');
+  const globalsCss = readFileSync(resolve(projectRoot, 'app/globals.css'), 'utf8');
+  const tokens = JSON.parse(
+    readFileSync(resolve(projectRoot, 'docs/design/system.tokens.v1.json'), 'utf8')
+  ) as {
+    tailwindV4: {
+      sources: string[];
+      themeTokens: Record<string, string>;
+    };
+  };
+
+  it('keeps Tailwind v4 CSS-first directives in app/globals.css', () => {
+    expect(globalsCss).toContain('@import "tailwindcss";');
+
+    for (const source of tokens.tailwindV4.sources) {
+      expect(globalsCss).toContain(`@source "${source}";`);
+    }
+  });
+
+  it('declares all required design tokens inside @theme', () => {
+    for (const cssVariableName of Object.values(tokens.tailwindV4.themeTokens)) {
+      expect(globalsCss).toContain(`${cssVariableName}:`);
+    }
+  });
+
+  it('keeps global shell styling aligned with flat-color visual constraints', () => {
+    expect(globalsCss).not.toContain('linear-gradient');
+    expect(globalsCss).not.toContain('radial-gradient');
+    expect(globalsCss).not.toContain('box-shadow');
+    expect(globalsCss).not.toContain("'Georgia'");
+    expect(globalsCss).not.toContain('Times New Roman');
+  });
+});


### PR DESCRIPTION
### Motivation
- Closes #86 by enforcing the design token / Tailwind v4 CSS-first contract at the global shell level so runtime UI surfaces comply with the locked visual-system specification.
- Ensure the public shell uses tokenized flat colors and approved typography (no gradients, shadows, or serif headline treatment) as required by the project's design documents.

### Description
- Reworked `app/globals.css` to remove gradient and box-shadow usages and switched shell surfaces (body, buttons, media cards, cards, CTA panels) to reference tokenized CSS variables (for example `var(--bg)`, `var(--surface)`, `var(--accent)`).
- Aligned global heading and brand copy to the canonical sans-serif tokenized headline treatment by switching to `var(--font-primary)`, enforcing `font-weight: 700`, `letter-spacing: var(--tracking-headline)`, and `text-transform: uppercase` for `h1`/`h2`.
- Tightened transitions to avoid shadow animation, replaced primary button gradient with tokenized background and `border-color` usage, and preserved `@import "tailwindcss"`, `@source` directives, and `@theme` block to keep the Tailwind v4 CSS-first setup intact.
- Added `tests/unit/design-tokens-contract.test.ts` which asserts presence of the Tailwind CSS-first directives, required token CSS variables from `docs/design/system.tokens.v1.json`, and the absence of prohibited visual constructs (`linear-gradient`, `radial-gradient`, `box-shadow`, and serif headline fonts).

### Testing
- Ran `pnpm lint` and it completed successfully with no new lint errors.
- Ran `pnpm typecheck` ( `tsc --noEmit` ) and it completed successfully with no type errors.
- Ran `pnpm test` and all unit and integration suites passed (Test Files 17 passed; Tests 64 passed).
- Ran `pnpm build` and Next.js production build completed successfully.
- Playwright/e2e was not required for this token/style-only scope; a container Playwright screenshot attempt failed due to an environment browser crash and was not used as a gating check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f388af78883279f18570f496ef947)