### PR TITLE
[WIP] [DESIGN-003] Align wraps routes and copy with design system

### DIFF
--- a/app/(tenant)/wraps/[id]/page.tsx
+++ b/app/(tenant)/wraps/[id]/page.tsx
@@ -23,7 +23,7 @@ export default async function WrapDetailsPage({ params }: WrapDetailsPageProps) 
   return (
     <main className="mx-auto grid w-full max-w-4xl gap-4 px-5 py-10 md:px-6">
       <p className="text-sm uppercase tracking-[0.08em] text-[color:var(--text-muted)]">
-        {tenant.slug.toUpperCase()} / Wrap Details
+        {tenant.slug.toUpperCase()} / Wraps
       </p>
       <WrapCatalogDetail wrap={wrap} />
     </main>

--- a/app/(tenant)/wraps/page.tsx
+++ b/app/(tenant)/wraps/page.tsx
@@ -10,11 +10,12 @@ export default async function WrapsPage() {
 
   return (
     <main className="mx-auto grid w-full max-w-5xl gap-4 px-5 py-10 md:px-6">
-      <h1 className="text-4xl font-semibold tracking-[0.02em] text-[color:var(--text)]">
-        {tenant.slug.toUpperCase()} Wrap Catalog
-      </h1>
+      <p className="text-sm uppercase tracking-[0.08em] text-[color:var(--text-muted)]">
+        {tenant.slug.toUpperCase()} / Wraps
+      </p>
+      <h1 className="text-4xl font-semibold tracking-[0.02em] text-[color:var(--text)]">Wrap catalog</h1>
       <p className="max-w-3xl text-[color:var(--text-muted)]">
-        Rendered as a server component with cached catalog fetchers.
+        Review available wrap options and open details to continue planning.
       </p>
       <WrapCatalogList wraps={wraps} />
     </main>

--- a/features/catalog/components/wrap-catalog-detail.tsx
+++ b/features/catalog/components/wrap-catalog-detail.tsx
@@ -8,10 +8,10 @@ export function WrapCatalogDetail({ wrap }: WrapCatalogDetailProps) {
   return (
     <article className="grid gap-3 rounded-2xl border border-[color:var(--border)] bg-[color:var(--surface)] p-5">
       <h1 className="text-3xl font-semibold text-[color:var(--text)]">{wrap.name}</h1>
-      <p className="text-[color:var(--text-muted)]">{wrap.description ?? 'No description provided.'}</p>
+      <p className="text-[color:var(--text-muted)]">{wrap.description ?? 'Details available on request.'}</p>
       <p className="text-lg font-semibold text-[color:var(--text)]">${(wrap.priceCents / 100).toFixed(2)}</p>
       <p className="text-sm font-medium text-[color:var(--text-muted)]">
-        Status: {wrap.isPublished ? 'Published' : 'Draft'}
+        Availability: {wrap.isPublished ? 'Published' : 'Draft'}
       </p>
     </article>
   );

--- a/features/catalog/components/wrap-catalog-list.tsx
+++ b/features/catalog/components/wrap-catalog-list.tsx
@@ -10,7 +10,7 @@ export function WrapCatalogList({ wraps }: WrapCatalogListProps) {
   if (wraps.length === 0) {
     return (
       <p className="rounded-lg border border-[color:var(--border)] bg-[color:var(--surface-muted)] p-4 text-[color:var(--text-muted)]">
-        No published wraps found.
+        No wraps are currently available.
       </p>
     );
   }
@@ -23,13 +23,13 @@ export function WrapCatalogList({ wraps }: WrapCatalogListProps) {
           key={wrap.id}
         >
           <h2 className="text-xl font-semibold text-[color:var(--text)]">{wrap.name}</h2>
-          <p className="text-[color:var(--text-muted)]">{wrap.description ?? 'No description provided.'}</p>
+          <p className="text-[color:var(--text-muted)]">{wrap.description ?? 'Details available on request.'}</p>
           <p className="font-semibold text-[color:var(--text)]">${(wrap.priceCents / 100).toFixed(2)}</p>
           <Link
             className="inline-flex w-fit items-center gap-1 font-semibold text-[color:var(--color-accent-primary)] hover:underline"
             href={`/wraps/${wrap.id}`}
           >
-            View details
+            Review wrap
           </Link>
         </li>
       ))}


### PR DESCRIPTION
### Motivation
- Closes #88 — align tenant-facing wraps list and detail routes with the design system by standardizing breadcrumb treatment and updating copy/CTAs while preserving server-side tenancy and fetcher boundaries.

### Description
- Updated `app/(tenant)/wraps/page.tsx` to use a consistent tenant breadcrumb (`TENANT / Wraps`) and concise hero copy, while keeping `getRequestTenant()` and `getPublicWraps()` server-side usage.
- Updated `app/(tenant)/wraps/[id]/page.tsx` to match the breadcrumb treatment and continue using `getRequestTenant()` and `getPublicWrapById()` for tenant-scoped reads.
- Refined presentation copy in `features/catalog/components/wrap-catalog-list.tsx` and `features/catalog/components/wrap-catalog-detail.tsx` to use concise professional language and updated CTA to `Review wrap`.
- No Prisma usage was added to `app/` routes and changes are limited to wraps routes and catalog presentation components.

### Testing
- Ran `pnpm lint` — failed due to pre-existing repository-wide lint/type errors unrelated to these small presentation changes (ESLint reported many `@typescript-eslint` issues outside the touched files).
- Ran `pnpm typecheck` — failed due to a missing runtime/dependency (`zod`) in the environment which surfaced as type-resolution errors, unrelated to the changed UI strings.
- Ran `pnpm test` — failed because test imports exercise action modules that depend on `zod` (dependency resolution error), causing several integration suites to error; no failing tests were caused by the changed files themselves.
- Ran `pnpm test:e2e` — failed for the same missing `zod` dependency in action modules.
- Pre-commit hook (`lint-staged` + `eslint` on staged files) executed during the commit and succeeded for the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3adf4d188327b197b6a235c1b87f)