### PR TITLE
[WIP] [DESIGN-004] Align auth routes and copy with design spec

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -5,9 +5,9 @@ import Link from 'next/link';
 import { PublicSiteShell } from '../../../../components/public/public-site-shell';
 
 const signInHighlights = [
-  'Resume your saved wrap previews and booking progress.',
-  'Review upcoming drop-off and pick-up windows in one place.',
-  'Track invoice and payment status without leaving the flow.'
+  'Resume saved wrap previews and continue booking where you left off.',
+  'Review upcoming drop-off and pick-up windows in one dashboard.',
+  'Track invoice and payment status without leaving your account.'
 ];
 
 export const metadata: Metadata = {
@@ -20,11 +20,11 @@ export default function SignInPage() {
       <main className="auth-main" id="main-content">
         <section className="section-shell auth-section">
           <article className="card auth-card">
-            <p className="eyebrow">Welcome Back</p>
-            <h1 className="auth-card__title">Sign in to continue your CTRL+ wrap journey.</h1>
+            <p className="eyebrow">Sign In</p>
+            <h1 className="auth-card__title">Welcome back to CTRL+.</h1>
             <p className="auth-card__description">
-              Use your email identity provider to access your account and continue from the exact
-              point where you left the funnel.
+              Continue with your email identity provider to access your account and move from
+              design selection to confirmed booking.
             </p>
 
             <ul className="auth-card__list">
@@ -35,24 +35,24 @@ export default function SignInPage() {
 
             <div className="auth-card__actions">
               <Link className="button button--primary" href="/sign-up">
-                Need Access? Sign Up
+                Create Account
               </Link>
               <Link className="button button--ghost" href="/features">
-                Review Features
+                Explore Features
               </Link>
             </div>
 
             <p className="auth-card__support">
-              New to CTRL+?{' '}
+              Need an account?{' '}
               <Link className="inline-link" href="/sign-up">
-                Create your account
+                Sign up
               </Link>
             </p>
           </article>
 
           <aside className="card auth-panel">
             <div className="auth-panel__content">
-              <p className="eyebrow">Secure Session</p>
+              <p className="eyebrow">Secure Access</p>
               <h2>Sign in with Clerk to continue.</h2>
               <SignIn fallbackRedirectUrl="/wraps" path="/sign-in" routing="path" signUpUrl="/sign-up" />
             </div>

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -5,9 +5,9 @@ import Link from 'next/link';
 import { PublicSiteShell } from '../../../../components/public/public-site-shell';
 
 const signUpBenefits = [
-  'Start with high-impact wrap discovery and visual previews.',
-  'Save choices and continue through scheduling when ready.',
-  'Complete secure checkout with clear booking confirmation.'
+  'Browse premium wraps and save high-intent options in one place.',
+  'Launch previews quickly with upload and template-based visualizer flows.',
+  'Schedule installation and complete secure checkout with clear confirmation.'
 ];
 
 export const metadata: Metadata = {
@@ -20,11 +20,11 @@ export default function SignUpPage() {
       <main className="auth-main" id="main-content">
         <section className="section-shell auth-section auth-section--reverse">
           <article className="card auth-card">
-            <p className="eyebrow">Get Started</p>
-            <h1 className="auth-card__title">Create your CTRL+ account and launch your first wrap flow.</h1>
+            <p className="eyebrow">Sign Up</p>
+            <h1 className="auth-card__title">Create your CTRL+ account.</h1>
             <p className="auth-card__description">
-              Sign up once to unlock the full conversion journey from browse and visualize to
-              schedule and secure payment.
+              Sign up once to unlock the complete journey from wrap discovery and visual previews to
+              scheduling and payment.
             </p>
 
             <ul className="auth-card__list">
@@ -35,24 +35,24 @@ export default function SignUpPage() {
 
             <div className="auth-card__actions">
               <Link className="button button--primary" href="/features">
-                Explore Features First
+                Explore Features
               </Link>
               <Link className="button button--ghost" href="/contact">
-                Talk to the Team
+                Contact Team
               </Link>
             </div>
 
             <p className="auth-card__support">
               Already have an account?{' '}
               <Link className="inline-link" href="/sign-in">
-                Sign in now
+                Sign in
               </Link>
             </p>
           </article>
 
           <aside className="card auth-panel">
             <div className="auth-panel__content">
-              <p className="eyebrow">Why Sign Up</p>
+              <p className="eyebrow">Fast Onboarding</p>
               <h2>Create your account with Clerk.</h2>
               <SignUp fallbackRedirectUrl="/wraps" path="/sign-up" routing="path" signInUrl="/sign-in" />
             </div>

--- a/tests/integration/auth-copy.test.ts
+++ b/tests/integration/auth-copy.test.ts
@@ -1,0 +1,32 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const appRoot = path.resolve(process.cwd(), 'app', '(auth)');
+
+describe('auth page copy conventions', () => {
+  it('keeps sign-in content aligned with design copy standards', async () => {
+    const signInPath = path.join(appRoot, 'sign-in', '[[...sign-in]]', 'page.tsx');
+    const signInPage = await readFile(signInPath, 'utf8');
+
+    expect(signInPage).toContain('<p className="eyebrow">Sign In</p>');
+    expect(signInPage).toContain('Welcome back to CTRL+.');
+    expect(signInPage).toContain('Create Account');
+    expect(signInPage).toContain('Explore Features');
+    expect(signInPage).toContain('Need an account?');
+    expect(signInPage).toContain('signUpUrl="/sign-up"');
+  });
+
+  it('keeps sign-up content aligned with design copy standards', async () => {
+    const signUpPath = path.join(appRoot, 'sign-up', '[[...sign-up]]', 'page.tsx');
+    const signUpPage = await readFile(signUpPath, 'utf8');
+
+    expect(signUpPage).toContain('<p className="eyebrow">Sign Up</p>');
+    expect(signUpPage).toContain('Create your CTRL+ account.');
+    expect(signUpPage).toContain('Explore Features');
+    expect(signUpPage).toContain('Contact Team');
+    expect(signUpPage).toContain('Already have an account?');
+    expect(signUpPage).toContain('signInUrl="/sign-in"');
+  });
+});


### PR DESCRIPTION
### Motivation
- Closes #89: align the sign-in / sign-up pages with the updated design voice and CTA copy while preserving existing auth behavior and route naming.
- Ensure the sign-up catch-all segment remains `[[...sign-up]]` (no legacy `[[...sign-out]]`), and keep Clerk routing configuration unchanged.
- Add regression coverage to protect the auth copy and route wiring from future regressions.

### Description
- Normalized marketing copy and CTA labels in `app/(auth)/sign-in/[[...sign-in]]/page.tsx` to the new design tone (eyebrow, title, description, list items, CTAs, and panel eyebrow text). 
- Normalized marketing copy and CTA labels in `app/(auth)/sign-up/[[...sign-up]]/page.tsx` to the new design tone (eyebrow, title, description, list items, CTAs, and panel eyebrow text).
- Preserved Clerk component props and routing (`path="/sign-in"`, `path="/sign-up"`, `routing="path"`, `signInUrl`/`signUpUrl`) so auth behavior is unchanged.
- Added `tests/integration/auth-copy.test.ts` to assert the new copy, CTAs, and Clerk wiring are present and to lock in the `[[...sign-up]]` filename convention.

### Testing
- Ran `pnpm lint` which failed due to unrelated baseline lint issues in other server actions (multiple `@typescript-eslint` errors); failures are outside the files modified in this PR.
- Ran `pnpm typecheck` which failed due to missing/unaligned dependencies (notably unresolved `zod`) in the repository baseline and resulting TS errors outside the changed files.
- Ran `pnpm test`: the new `tests/integration/auth-copy.test.ts` and existing auth-routing checks passed, but the full test run had several failing suites (7 suites) caused by the unresolved `zod` dependency during import of shared actions; the auth copy tests themselves succeeded.
- Ran `pnpm test:e2e` which failed early due to the same missing `zod` module before auth e2e specs could execute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3ae379f48327b1988026d5db0795)