### PR TITLE
[WIP] [DESIGN-006] Sitewide copy consistency pass and QA guidance

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -43,7 +43,7 @@ export default function SignInPage() {
             </div>
 
             <p className="auth-card__support">
-              Need an account?{' '}
+              Need an account to continue?{' '}
               <Link className="inline-link" href="/sign-up">
                 Sign up
               </Link>

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { PublicSiteShell } from '../../../../components/public/public-site-shell';
 
 const signUpBenefits = [
-  'Browse premium wraps and save high-intent options in one place.',
+  'Browse wraps and save options in one place.',
   'Launch previews quickly with upload and template-based visualizer flows.',
   'Schedule installation and complete secure checkout with clear confirmation.'
 ];
@@ -52,7 +52,7 @@ export default function SignUpPage() {
 
           <aside className="card auth-panel">
             <div className="auth-panel__content">
-              <p className="eyebrow">Fast Onboarding</p>
+              <p className="eyebrow">Account Setup</p>
               <h2>Create your account with Clerk.</h2>
               <SignUp fallbackRedirectUrl="/wraps" path="/sign-up" routing="path" signInUrl="/sign-in" />
             </div>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -40,7 +40,7 @@ export default function AboutPage() {
           <div className="content-hero__copy">
             <p className="eyebrow">About CTRL+</p>
             <h1 className="content-hero__title">
-              Premium vehicle wrap services built around clarity, speed, and execution.
+              Vehicle wrap services built around clarity, speed, and execution.
             </h1>
             <p>
               CTRL+ helps customers and businesses move from concept to confirmed install through
@@ -94,10 +94,10 @@ export default function AboutPage() {
             </ul>
             <div className="split-section__actions">
               <Link className="button button--primary" href="/sign-up">
-                Start Now
+                Create Account
               </Link>
               <Link className="button button--ghost" href="/contact">
-                Contact Team
+                Contact Us
               </Link>
             </div>
           </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -95,7 +95,7 @@ export default function ContactPage() {
         <section className="section-shell split-section">
           <div className="card split-section__content">
             <p className="eyebrow">What Happens Next</p>
-            <h2>A straightforward workflow designed to turn intent into booked work.</h2>
+            <h2>A straightforward workflow designed to turn interest into booked work.</h2>
             <ul className="split-section__list">
               {nextSteps.map((nextStep) => (
                 <li key={nextStep}>{nextStep}</li>

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -47,7 +47,7 @@ const featureRows = [
       'Move from quote to paid booking through secure checkout and webhook-confirmed status updates.',
     points: [
       'Generate invoice context directly from booking details.',
-      'Use secure checkout for faster conversion.',
+      'Use secure checkout for direct payment completion.',
       'Reflect payment state in booking confirmations.'
     ],
     image: '/0001-5948623603194756924.png',
@@ -67,7 +67,7 @@ export default function FeaturesPage() {
           <div className="content-hero__copy">
             <p className="eyebrow">Platform Features</p>
             <h1 className="content-hero__title">
-              Core capabilities built to convert browsing into confirmed bookings.
+              Core capabilities built to move browsing into confirmed bookings.
             </h1>
             <p>
               Each feature supports the same objective: reduce friction and move customers from
@@ -86,7 +86,7 @@ export default function FeaturesPage() {
           <figure className="media-card media-card--feature">
             <Image
               src="/0001-6683836236957800475.png"
-              alt="CTRL+ premium vehicle wrap solutions"
+              alt="CTRL+ vehicle wrap workflow overview"
               fill
               priority
               sizes="(max-width: 980px) 100vw, 46vw"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ export default function HomePage() {
           <div className="hero__content">
             <p className="eyebrow">Command Your Brand · El Paso, Texas</p>
             <h1 className="hero__title">
-              Premium vehicle wraps, tint, and signage with a clear digital booking path.
+              Vehicle wraps, tint, and signage with a clear digital booking path.
             </h1>
             <p className="hero__description">
               CTRL+ helps customers move from initial concept to confirmed install in one guided
@@ -105,13 +105,13 @@ export default function HomePage() {
             <figure className="media-card media-card--primary">
               <Image
                 src="/0001-7280563191036061234.png"
-                alt="CTRL+ premium wrap showcase"
+                alt="CTRL+ wrap showcase"
                 fill
                 priority
                 sizes="(max-width: 980px) 100vw, 52vw"
               />
               <figcaption className="media-card__overlay">
-                Premium wraps presented with high-impact visuals.
+                Wrap options shown with clear visual references.
               </figcaption>
             </figure>
 
@@ -204,7 +204,7 @@ export default function HomePage() {
                 Create Account
               </Link>
               <Link className="button button--ghost" href="/about">
-                About CTRL+
+                About Us
               </Link>
             </div>
           </div>

--- a/components/public/public-site-shell.tsx
+++ b/components/public/public-site-shell.tsx
@@ -84,8 +84,7 @@ export function PublicSiteShell({ activePath, children }: PublicSiteShellProps) 
           <div className="site-footer__brand">
             <Image src="/0001-3757622370303829961.png" alt="CTRL+ mark" width={52} height={52} />
             <p>
-              Premium vehicle wraps, tint, and signage for El Paso businesses and drivers ready to
-              stand out.
+              Vehicle wraps, tint, and signage for El Paso businesses and drivers.
             </p>
           </div>
 
@@ -98,13 +97,13 @@ export function PublicSiteShell({ activePath, children }: PublicSiteShellProps) 
           </div>
 
           <div className="site-footer__cta">
-            <p>Ready to start your wrap project?</p>
+            <p>Ready to start your project?</p>
             <div className="site-footer__cta-actions">
               <Link className="button button--primary" href="/sign-up">
                 Create Account
               </Link>
               <Link className="button button--ghost" href="/sign-in">
-                Existing Client
+                Existing Customer
               </Link>
             </div>
           </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ This directory contains project guidance and report snapshots.
 - `docs/github-workflow.md`: labels, roadmap sync, and governance bootstrap.
 - `docs/ci-design.md`: CI quality gates and flaky-test handling policy.
 - `docs/pr-checklist.md`: merge checklist used by pull requests.
+- `docs/copy-style-guide.md`: approved sitewide copy tone and phrasing standards.
+- `docs/copy-qa-checklist.md`: route-level copy consistency and QA checklist.
 - `docs/deployment-runbook.md`: deployment sequence, migration safety, rollback, and verification flow.
 - `docs/demo-release-checklist.md`: M9 demo release readiness checklist.
 

--- a/docs/copy-qa-checklist.md
+++ b/docs/copy-qa-checklist.md
@@ -1,0 +1,38 @@
+# Sitewide Copy QA Checklist
+
+Use this checklist for issue-level copy consistency passes and for PR review of user-facing route changes.
+
+## Route coverage
+
+Validate the following route groups:
+
+- Public marketing routes (`/`, `/about`, `/features`, `/contact`)
+- Auth routes (`/sign-in`, `/sign-up`)
+- Tenant routes with user-facing text (`/wraps`, `/wraps/[id]`, `/admin` when copy changes)
+
+## Consistency checks
+
+- [ ] CTA labels are standardized (`Create Account`, `Sign In`, `View Features`, `Contact Us` where applicable)
+- [ ] Repeated workflow statements use consistent wording
+- [ ] Similar sections use consistent nouns (`customers`, `wraps`, `bookings`, `invoices`)
+- [ ] No route introduces contradictory terminology for the same action
+
+## Tone checks
+
+- [ ] Copy remains minimalist, clean, and professional
+- [ ] No hype/luxury words are present (`premium`, `luxury`, `elite`, etc.)
+- [ ] Claims are operationally verifiable (no inflated promises)
+
+## UI safety checks
+
+- [ ] Copy edits do not alter component hierarchy or class tokens
+- [ ] No visual-system deviations introduced during text changes
+- [ ] Accessibility labels remain accurate after wording changes
+
+## Verification commands
+
+Run the project quality gates after copy updates:
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`

--- a/docs/copy-style-guide.md
+++ b/docs/copy-style-guide.md
@@ -1,0 +1,54 @@
+# Site Copy Style Guide
+
+## Objective
+
+Keep all user-facing copy minimalist, clean, and professional. Content should guide users through the product flow without hype, luxury language, or marketing exaggeration.
+
+## Tone and voice
+
+- Use plain, direct language.
+- Prefer practical statements over promotional claims.
+- Keep sentence structure short and readable.
+- Focus on action clarity (what users can do next).
+
+## Approved style patterns
+
+- Primary CTA labels:
+  - `Create Account`
+  - `Sign In`
+  - `View Features`
+  - `Contact Us`
+- Workflow framing:
+  - `Browse → Preview → Schedule → Pay`
+  - `clear digital booking path`
+  - `secure checkout`
+- Neutral descriptors:
+  - `vehicle wraps`
+  - `wrap options`
+  - `account setup`
+
+## Disallowed language patterns
+
+Avoid adjectives and phrases that imply luxury, hype, or inflated claims in site copy.
+
+Examples to avoid:
+
+- `premium`
+- `high-impact`
+- `exclusive`
+- `best-in-class`
+- `world-class`
+- `elite`
+- `luxury`
+
+If emphasis is needed, use operational outcomes instead (for example: `clear scheduling windows`, `secure payment confirmation`).
+
+## Authoring checklist for copy edits
+
+Before merging copy changes:
+
+1. Confirm wording is concise and functional.
+2. Confirm CTA labels match approved patterns.
+3. Confirm no hype/luxury wording was introduced.
+4. Confirm copy still aligns to the conversion flow (browse, preview, schedule, pay).
+5. Confirm copy-only updates do not modify visual-system classes or layout structure.

--- a/docs/pr-checklist.md
+++ b/docs/pr-checklist.md
@@ -17,6 +17,7 @@ Use this checklist for every PR.
 - [ ] Auth + permission validated server-side
 - [ ] Zod validation added (if input)
 - [ ] No `console.log`s
+- [ ] Copy updates follow `docs/copy-style-guide.md` and `docs/copy-qa-checklist.md`
 - [ ] Deployment updates documented in `docs/deployment-runbook.md` (migration + rollback + verification)
 - [ ] Environment contract remains synchronized across `.env.example`, `README.md`, and deployment docs
 - [ ] Demo release criteria validated using `docs/demo-release-checklist.md` when applicable

--- a/tests/integration/auth-copy.test.ts
+++ b/tests/integration/auth-copy.test.ts
@@ -14,7 +14,7 @@ describe('auth page copy conventions', () => {
     expect(signInPage).toContain('Welcome back to CTRL+.');
     expect(signInPage).toContain('Create Account');
     expect(signInPage).toContain('Explore Features');
-    expect(signInPage).toContain('Need an account?');
+    expect(signInPage).toContain('Need an account to continue?');
     expect(signInPage).toContain('signUpUrl="/sign-up"');
   });
 

--- a/tests/integration/site-copy-governance.test.ts
+++ b/tests/integration/site-copy-governance.test.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const routeFiles = [
+  'app/page.tsx',
+  'app/about/page.tsx',
+  'app/features/page.tsx',
+  'app/contact/page.tsx',
+  'app/(auth)/sign-in/[[...sign-in]]/page.tsx',
+  'app/(auth)/sign-up/[[...sign-up]]/page.tsx',
+  'app/(tenant)/wraps/page.tsx',
+  'app/(tenant)/wraps/[id]/page.tsx',
+  'app/(tenant)/admin/page.tsx',
+  'components/public/public-site-shell.tsx',
+  'features/catalog/components/wrap-catalog-list.tsx',
+  'features/catalog/components/wrap-catalog-detail.tsx'
+] as const;
+
+const blockedTerms = ['premium', 'luxury', 'elite', 'best-in-class', 'world-class', 'exclusive'] as const;
+
+describe('site copy governance', () => {
+  it('avoids blocked hype terms in user-facing routes and components', async () => {
+    for (const routeFile of routeFiles) {
+      const absolutePath = path.resolve(process.cwd(), routeFile);
+      const content = (await readFile(absolutePath, 'utf8')).toLowerCase();
+
+      for (const blockedTerm of blockedTerms) {
+        expect(
+          content.includes(blockedTerm),
+          `${routeFile} must not include blocked term: ${blockedTerm}`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('keeps primary auth CTAs consistent across public shell and auth routes', async () => {
+    const shellContent = await readFile(path.resolve(process.cwd(), 'components/public/public-site-shell.tsx'), 'utf8');
+    const signInContent = await readFile(
+      path.resolve(process.cwd(), 'app/(auth)/sign-in/[[...sign-in]]/page.tsx'),
+      'utf8'
+    );
+    const signUpContent = await readFile(
+      path.resolve(process.cwd(), 'app/(auth)/sign-up/[[...sign-up]]/page.tsx'),
+      'utf8'
+    );
+
+    expect(shellContent).toContain('Create Account');
+    expect(shellContent).toContain('Sign In');
+    expect(signInContent).toContain('Create Account');
+    expect(signUpContent).toContain('Already have an account?');
+  });
+});


### PR DESCRIPTION
### Motivation
- Closes #91 — enforce a consistent, minimalist site copy tone across public, auth, and tenant-facing routes and provide a QA checklist and test coverage to prevent regressions.
- Remove promotional/hype phrasing and standardize primary CTAs and workflow language to keep user-facing copy direct and operational.

### Description
- Performed a sitewide copy pass updating wording in `app/page.tsx`, `app/about/page.tsx`, `app/features/page.tsx`, `app/contact/page.tsx`, the public shell `components/public/public-site-shell.tsx`, and auth pages under `app/(auth)` to remove blocked terms and align CTAs (e.g., `Create Account`, `Sign In`, `View Features`, `Contact Us`).
- Added documentation files `docs/copy-style-guide.md` and `docs/copy-qa-checklist.md`, and updated `docs/README.md` and `docs/pr-checklist.md` to surface copy governance in the PR process.
- Added integration test `tests/integration/site-copy-governance.test.ts` to block specified hype terms and assert CTA consistency, and adjusted `tests/integration/auth-copy.test.ts` to match revised auth copy.
- This is a copy/docs/tests-only change with no modifications to Prisma, server actions, tenant resolution, or visual-system tokens/classes.

### Testing
- Ran quality gates: `pnpm lint` (passed), `pnpm typecheck` (passed), and `pnpm test` (Vitest) which passed after fixing one match in alt text; all tests are green.
- Initial test run surfaced a blocked-term failure which was corrected and re-run, and the added governance test now passes in CI-local run.
- Dev server start attempted during verification and reported a missing Clerk `secretKey` in the environment (expected in this dev environment), and a Playwright screenshot was captured for a local smoke snapshot despite the auth warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3d5bca408327ad29005958484ed5)