### PR TITLE
[WIP] [DESIGN-007] Route-by-route design compliance validation and e2e coverage

### DIFF
--- a/tests/e2e/design-route-compliance.spec.ts
+++ b/tests/e2e/design-route-compliance.spec.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+import {
+  DESIGN_000_BLOCKED_TERMS,
+  DESIGN_000_ROUTE_MATRIX
+} from '../fixtures/design-000-route-matrix.fixture';
+
+test.describe('DESIGN-000 route compliance matrix', () => {
+  test('validates required route snippets and blocked terms for each route', async () => {
+    for (const routeExpectation of DESIGN_000_ROUTE_MATRIX) {
+      const absolutePath = path.resolve(process.cwd(), routeExpectation.filePath);
+      const content = await readFile(absolutePath, 'utf8');
+      const normalizedContent = content.toLowerCase();
+
+      for (const requiredSnippet of routeExpectation.requiredSnippets) {
+        expect(
+          content,
+          `${routeExpectation.route} (${routeExpectation.filePath}) missing snippet: ${requiredSnippet}`
+        ).toContain(requiredSnippet);
+      }
+
+      for (const blockedTerm of DESIGN_000_BLOCKED_TERMS) {
+        expect(
+          normalizedContent.includes(blockedTerm),
+          `${routeExpectation.route} (${routeExpectation.filePath}) includes blocked term: ${blockedTerm}`
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/tests/fixtures/design-000-route-matrix.fixture.ts
+++ b/tests/fixtures/design-000-route-matrix.fixture.ts
@@ -1,0 +1,98 @@
+export interface DesignRouteExpectation {
+  readonly route: string;
+  readonly filePath: string;
+  readonly requiredSnippets: readonly string[];
+}
+
+export const DESIGN_000_BLOCKED_TERMS = [
+  'premium',
+  'luxury',
+  'elite',
+  'best-in-class',
+  'world-class',
+  'exclusive'
+] as const;
+
+export const DESIGN_000_ROUTE_MATRIX: readonly DesignRouteExpectation[] = [
+  {
+    route: '/',
+    filePath: 'app/page.tsx',
+    requiredSnippets: [
+      'Vehicle wraps, tint, and signage with a clear digital booking path.',
+      'className="hero__title"',
+      'Create Account',
+      'Sign In'
+    ]
+  },
+  {
+    route: '/about',
+    filePath: 'app/about/page.tsx',
+    requiredSnippets: [
+      '<p className="eyebrow">About CTRL+</p>',
+      'Vehicle wrap services built around clarity, speed, and execution.',
+      'className="content-hero__title"',
+      'View Features'
+    ]
+  },
+  {
+    route: '/features',
+    filePath: 'app/features/page.tsx',
+    requiredSnippets: [
+      '<p className="eyebrow">Platform Features</p>',
+      'Each feature supports the same objective: reduce friction and move customers from',
+      'feature-row card',
+      'Sign Up'
+    ]
+  },
+  {
+    route: '/contact',
+    filePath: 'app/contact/page.tsx',
+    requiredSnippets: [
+      '<p className="eyebrow">Contact</p>',
+      'Whether you are wrapping one vehicle or a full fleet, we provide a direct path from',
+      'className="contact-grid"',
+      'Create Account'
+    ]
+  },
+  {
+    route: '/sign-in',
+    filePath: 'app/(auth)/sign-in/[[...sign-in]]/page.tsx',
+    requiredSnippets: [
+      '<p className="eyebrow">Sign In</p>',
+      'Welcome back to CTRL+.',
+      '<SignIn fallbackRedirectUrl="/wraps" path="/sign-in" routing="path" signUpUrl="/sign-up" />'
+    ]
+  },
+  {
+    route: '/sign-up',
+    filePath: 'app/(auth)/sign-up/[[...sign-up]]/page.tsx',
+    requiredSnippets: [
+      '<p className="eyebrow">Sign Up</p>',
+      'Create your CTRL+ account.',
+      '<SignUp fallbackRedirectUrl="/wraps" path="/sign-up" routing="path" signInUrl="/sign-in" />'
+    ]
+  },
+  {
+    route: '/wraps',
+    filePath: 'app/(tenant)/wraps/page.tsx',
+    requiredSnippets: [
+      'Wrap catalog',
+      'Review available wrap options and open details to continue planning.',
+      '<WrapCatalogList wraps={wraps} />'
+    ]
+  },
+  {
+    route: '/wraps/[id]',
+    filePath: 'app/(tenant)/wraps/[id]/page.tsx',
+    requiredSnippets: ['<WrapCatalogDetail wrap={wrap} />', '/ Wraps']
+  },
+  {
+    route: '/admin',
+    filePath: 'app/(tenant)/admin/page.tsx',
+    requiredSnippets: [
+      'Admin / Operations',
+      'Operations Dashboard',
+      'className="text-2xl font-semibold text-[color:var(--text)]">Performance Snapshot</h2>'
+    ]
+  }
+] as const;


### PR DESCRIPTION
### Motivation
- Closes #92.
- Prevent visual and copy regressions by adding a deterministic, route-by-route DESIGN-000 validation matrix that CI can enforce.
- Keep tests CI-friendly and align with existing PR quality gates and conditional `test-e2e` triggers.

### Description
- Add `tests/fixtures/design-000-route-matrix.fixture.ts` that declares per-route expectations and blocked hype terms for every `app/**/page.tsx` route.
- Update integration governance checks in `tests/integration/site-copy-governance.test.ts` to assert matrix-to-route alignment, required snippet presence, and blocked-term absence.
- Add Playwright e2e spec `tests/e2e/design-route-compliance.spec.ts` that validates the full DESIGN-000 matrix during the `test:e2e` stage.
- No runtime or data-layer changes were made and tenant/auth boundaries were not modified (tests-only changes; no Prisma usage added in `app/`).

### Testing
- Ran `pnpm lint` and it passed.
- Ran `pnpm typecheck` and it passed.
- Ran `pnpm test` (Vitest unit + integration) and all tests passed.
- Ran `pnpm test:e2e` (Playwright) and all e2e specs passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3f0563688327b12eb63ada03f9ea)