### PR TITLE
Add shared Clerk appearance config and wire into app provider

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { ClerkProvider } from '@clerk/nextjs';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
+import { appearance } from '../lib/auth/clerk-appearance';
 import { getClerkPublishableKey } from '../lib/auth/clerk-config';
 
 export const metadata: Metadata = {
@@ -22,7 +23,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
   const publishableKey = getClerkPublishableKey();
 
   return (
-    <ClerkProvider publishableKey={publishableKey}>
+    <ClerkProvider appearance={appearance} publishableKey={publishableKey}>
       <html lang="en">
         <body>{children}</body>
       </html>

--- a/lib/auth/clerk-appearance.ts
+++ b/lib/auth/clerk-appearance.ts
@@ -1,0 +1,19 @@
+import { ClerkProvider } from '@clerk/nextjs';
+import type { ComponentProps } from 'react';
+
+export const appearance = {
+  variables: {
+    colorBackground: '#0E1A3A',
+    colorText: '#F8F9FB',
+    colorInputBackground: '#10254A',
+    colorPrimary: '#1F46E0'
+  },
+  elements: {
+    card: 'rounded-[18px] border border-[rgba(216,219,244,0.25)] bg-[#10254a] shadow-[0_24px_54px_rgba(2,10,28,0.45)]',
+    formButtonPrimary:
+      'rounded-full border border-[#1234B5] bg-[#1F46E0] text-[#F8F9FB] transition hover:bg-[#1234B5] focus-visible:ring-2 focus-visible:ring-[#D8DBF4] focus-visible:ring-offset-2 focus-visible:ring-offset-[#10254A]',
+    socialButtonsBlockButton:
+      'rounded-full border border-[rgba(216,219,244,0.25)] bg-[#102952] text-[#F8F9FB] transition hover:border-[#1F46E0] hover:bg-[#162c53] focus-visible:ring-2 focus-visible:ring-[#D8DBF4] focus-visible:ring-offset-2 focus-visible:ring-offset-[#10254A]',
+    footerActionLink: 'font-semibold text-[#D8DBF4] underline-offset-4 hover:text-[#F8F9FB] hover:underline'
+  }
+} satisfies NonNullable<ComponentProps<typeof ClerkProvider>['appearance']>;


### PR DESCRIPTION
### Motivation

- Centralize Clerk UI theming so the app and Clerk primitives share the same dark-mode palette and visual language. 
- Ensure Clerk components use the existing CTRL+ design tokens (background, text, inputs, primary) for a consistent, high-contrast shadcn-like look. 
- This is a styling-only change and does not modify any auth, tenancy, or permission logic.

### Description

- Added a shared appearance object at `lib/auth/clerk-appearance.ts` that maps dark-mode tokens `colorBackground`, `colorText`, `colorInputBackground`, and `colorPrimary` to the existing palette. 
- Provided targeted element styling inside the same file for Clerk primitives `card`, `formButtonPrimary`, `socialButtonsBlockButton`, and `footerActionLink` to match rounded, high-contrast visuals. 
- Wired the shared `appearance` into the root provider by passing `appearance={appearance}` into `ClerkProvider` in `app/layout.tsx` while preserving the existing `publishableKey` resolution. 
- The exported `appearance` is typed using `satisfies NonNullable<ComponentProps<typeof ClerkProvider>['appearance']>` to keep compile-time compatibility with `@clerk/nextjs` props.

### Testing

- Ran `pnpm typecheck` and it completed successfully. 
- Ran `pnpm lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1050835bc8327a7b3ceb101c1595e)