### PR TITLE
Add reduced 'auth' header variant to PublicSiteShell

### DIFF
--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 
 export default function SignInPage() {
   return (
-    <PublicSiteShell activePath="/sign-in">
+    <PublicSiteShell activePath="/sign-in" variant="auth">
       <main className="auth-main" id="main-content">
         <section className="section-shell auth-section">
           <article className="card auth-card">

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 
 export default function SignUpPage() {
   return (
-    <PublicSiteShell activePath="/sign-up">
+    <PublicSiteShell activePath="/sign-up" variant="auth">
       <main className="auth-main" id="main-content">
         <section className="section-shell auth-section auth-section--reverse">
           <article className="card auth-card">

--- a/components/public/public-site-shell.tsx
+++ b/components/public/public-site-shell.tsx
@@ -13,6 +13,7 @@ const navigationLinks = [
 type PublicSiteShellProps = {
   readonly activePath: string;
   readonly children: ReactNode;
+  readonly variant?: 'default' | 'auth';
 };
 
 function getNavigationLinkClassName(href: string, activePath: string): string {
@@ -22,7 +23,9 @@ function getNavigationLinkClassName(href: string, activePath: string): string {
   return isActive ? 'site-nav__link site-nav__link--active' : 'site-nav__link';
 }
 
-export function PublicSiteShell({ activePath, children }: PublicSiteShellProps) {
+export function PublicSiteShell({ activePath, children, variant = 'default' }: PublicSiteShellProps) {
+  const isAuthVariant = variant === 'auth';
+
   return (
     <div className="public-site">
       <a className="skip-link" href="#main-content">
@@ -46,27 +49,31 @@ export function PublicSiteShell({ activePath, children }: PublicSiteShellProps) 
             </span>
           </Link>
 
-          <nav aria-label="Primary" className="site-nav">
-            {navigationLinks.map((navigationLink) => (
-              <Link
-                key={navigationLink.href}
-                className={getNavigationLinkClassName(navigationLink.href, activePath)}
-                href={navigationLink.href}
-              >
-                {navigationLink.label}
-              </Link>
-            ))}
-          </nav>
+          {!isAuthVariant ? (
+            <nav aria-label="Primary" className="site-nav">
+              {navigationLinks.map((navigationLink) => (
+                <Link
+                  key={navigationLink.href}
+                  className={getNavigationLinkClassName(navigationLink.href, activePath)}
+                  href={navigationLink.href}
+                >
+                  {navigationLink.label}
+                </Link>
+              ))}
+            </nav>
+          ) : null}
 
           <div className="site-header__actions">
-            <SignedOut>
-              <Link className="button button--ghost" href="/sign-in">
-                Sign In
-              </Link>
-              <Link className="button button--primary" href="/sign-up">
-                Sign Up
-              </Link>
-            </SignedOut>
+            {!isAuthVariant ? (
+              <SignedOut>
+                <Link className="button button--ghost" href="/sign-in">
+                  Sign In
+                </Link>
+                <Link className="button button--primary" href="/sign-up">
+                  Sign Up
+                </Link>
+              </SignedOut>
+            ) : null}
             <SignedIn>
               <Link className="button button--ghost" href="/wraps">
                 Dashboard


### PR DESCRIPTION
### Motivation
- Reduce header clutter on authentication pages while preserving branding, accessibility (skip link), and access for already-authenticated users.
- Provide a simple, typed opt-in variant on the shared public shell so auth routes can render a compact header without duplicating layout code.

### Description
- Add an optional `variant?: 'default' | 'auth'` prop to `PublicSiteShell` and default it to `'default'`, and compute `isAuthVariant` for conditional rendering.
- When `variant === 'auth'` the component hides the primary navigation and the `SignedOut` CTAs but preserves the brand link, the skip-link, footer, and `SignedIn` controls (dashboard link + `UserButton`).
- Wire `variant="auth"` into the auth pages at `app/(auth)/sign-in/[[...sign-in]]/page.tsx` and `app/(auth)/sign-up/[[...sign-up]]/page.tsx` to enable the reduced header for those routes.

### Testing
- Ran `pnpm typecheck` which completed successfully.
- Executed the Playwright script to capture a rendering of `/sign-in`, producing a screenshot artifact confirming the reduced header in a browser context.
- Linting hooks (`lint-staged`/`eslint`) ran as part of the change workflow and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10509e70c8327938e5f2fccd8fd37)