### PR TITLE
Modernize auth integration tests around stable contracts

### DIFF
--- a/tests/integration/auth-copy.test.ts
+++ b/tests/integration/auth-copy.test.ts
@@ -5,28 +5,29 @@ import { describe, expect, it } from 'vitest';
 
 const appRoot = path.resolve(process.cwd(), 'app', '(auth)');
 
-describe('auth page copy conventions', () => {
-  it('keeps sign-in content aligned with design copy standards', async () => {
-    const signInPath = path.join(appRoot, 'sign-in', '[[...sign-in]]', 'page.tsx');
+const signInPath = path.join(appRoot, 'sign-in', '[[...sign-in]]', 'page.tsx');
+const signUpPath = path.join(appRoot, 'sign-up', '[[...sign-up]]', 'page.tsx');
+
+describe('auth page copy and CTA contracts', () => {
+  it('keeps sign-in page structure with primary heading, CTA destinations, and sign-up cross-link', async () => {
     const signInPage = await readFile(signInPath, 'utf8');
 
-    expect(signInPage).toContain('<p className="eyebrow">Sign In</p>');
-    expect(signInPage).toContain('Welcome back to CTRL+.');
-    expect(signInPage).toContain('Create Account');
-    expect(signInPage).toContain('Explore Features');
-    expect(signInPage).toContain('Need an account to continue?');
+    expect(signInPage).toMatch(/<h1\b[^>]*>[\s\S]*?<\/h1>/);
+    expect(signInPage).toContain('href="/sign-up"');
     expect(signInPage).toContain('signUpUrl="/sign-up"');
+
+    expect(signInPage).toContain('href="/features"');
+    expect(signInPage).toContain('Create Account');
   });
 
-  it('keeps sign-up content aligned with design copy standards', async () => {
-    const signUpPath = path.join(appRoot, 'sign-up', '[[...sign-up]]', 'page.tsx');
+  it('keeps sign-up page structure with primary heading, CTA destinations, and sign-in cross-link', async () => {
     const signUpPage = await readFile(signUpPath, 'utf8');
 
-    expect(signUpPage).toContain('<p className="eyebrow">Sign Up</p>');
-    expect(signUpPage).toContain('Create your CTRL+ account.');
-    expect(signUpPage).toContain('Explore Features');
-    expect(signUpPage).toContain('Contact Team');
-    expect(signUpPage).toContain('Already have an account?');
+    expect(signUpPage).toMatch(/<h1\b[^>]*>[\s\S]*?<\/h1>/);
+    expect(signUpPage).toContain('href="/sign-in"');
     expect(signUpPage).toContain('signInUrl="/sign-in"');
+
+    expect(signUpPage).toContain('href="/features"');
+    expect(signUpPage).toContain('href="/contact"');
   });
 });

--- a/tests/integration/auth-routing.test.ts
+++ b/tests/integration/auth-routing.test.ts
@@ -1,38 +1,34 @@
-import { readFile } from 'node:fs/promises';
+import { access, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 const appRoot = path.resolve(process.cwd(), 'app', '(auth)');
 
-describe('auth route file conventions', () => {
-  it('uses the correct sign-in and sign-up catch-all segment names', async () => {
-    const signInPath = path.join(appRoot, 'sign-in', '[[...sign-in]]', 'page.tsx');
-    const signUpPath = path.join(appRoot, 'sign-up', '[[...sign-up]]', 'page.tsx');
+const signInPath = path.join(appRoot, 'sign-in', '[[...sign-in]]', 'page.tsx');
+const signUpPath = path.join(appRoot, 'sign-up', '[[...sign-up]]', 'page.tsx');
 
-    await expect(readFile(signInPath, 'utf8')).resolves.toContain('export default function SignInPage');
-    await expect(readFile(signUpPath, 'utf8')).resolves.toContain('export default function SignUpPage');
+describe('auth route integration contracts', () => {
+  it('keeps sign-in and sign-up pages on the expected catch-all route segments', async () => {
+    await expect(access(signInPath)).resolves.toBeUndefined();
+    await expect(access(signUpPath)).resolves.toBeUndefined();
+
+    const invalidSignUpSegmentPath = path.join(appRoot, 'sign-up', '[[...sign-out]]', 'page.tsx');
+    await expect(access(invalidSignUpSegmentPath)).rejects.toThrowError();
   });
 
-  it('does not regress to the invalid sign-up segment name', async () => {
-    const invalidPath = path.join(appRoot, 'sign-up', '[[...sign-out]]', 'page.tsx');
-
-    await expect(readFile(invalidPath, 'utf8')).rejects.toThrowError();
-  });
-
-  it('keeps Clerk path routing aligned with the route segments', async () => {
-    const signInPath = path.join(appRoot, 'sign-in', '[[...sign-in]]', 'page.tsx');
-    const signUpPath = path.join(appRoot, 'sign-up', '[[...sign-up]]', 'page.tsx');
-
+  it('renders Clerk auth components with stable path routing contracts', async () => {
     const [signInPage, signUpPage] = await Promise.all([
       readFile(signInPath, 'utf8'),
       readFile(signUpPath, 'utf8')
     ]);
 
+    expect(signInPage).toMatch(/<SignIn\b/);
     expect(signInPage).toContain('path="/sign-in"');
     expect(signInPage).toContain('routing="path"');
     expect(signInPage).toContain('signUpUrl="/sign-up"');
 
+    expect(signUpPage).toMatch(/<SignUp\b/);
     expect(signUpPage).toContain('path="/sign-up"');
     expect(signUpPage).toContain('routing="path"');
     expect(signUpPage).toContain('signInUrl="/sign-in"');


### PR DESCRIPTION
### Motivation

- Reduce brittleness in auth page tests by validating structural and integration contracts instead of exact marketing copy.
- Preserve critical Clerk integration checks (component presence and `path`/`routing`/cross-link props) to guard routing and auth wiring regressions.
- Keep tests isolated to auth page source contracts with no DB or network dependencies.

### Description

- Rewrote `tests/integration/auth-routing.test.ts` to assert file presence with `access()`, reject an invalid catch-all segment, and verify Clerk components with regex plus `path`, `routing`, and sign-in/sign-up prop checks.
- Rewrote `tests/integration/auth-copy.test.ts` to assert presence of a primary `<h1>`, required CTA/link destinations (`/features`, `/contact`, `/sign-up`, `/sign-in`), and the sign-in/sign-up cross-links instead of literal marketing text.
- Added structural assertions for `<SignIn` and `<SignUp` occurrences to ensure Clerk components are still rendered with required props.
- No application code or runtime behavior was changed; only the two integration test files were updated (`tests/integration/auth-routing.test.ts` and `tests/integration/auth-copy.test.ts`).

### Testing

- Ran `pnpm vitest tests/integration/auth-routing.test.ts tests/integration/auth-copy.test.ts` and both test files passed (4 tests total).
- Tests remain fast, deterministic, and free of external network or DB dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1050b1d94832793a5f98ec89e79e4)