### PR TITLE
Extract auth-specific styles into auth segment stylesheet and scope selectors

### DIFF
--- a/app/(auth)/auth.css
+++ b/app/(auth)/auth.css
@@ -1,0 +1,96 @@
+.auth-main {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 2.25rem 0 4.8rem;
+}
+
+.auth-main .auth-section {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.auth-main .auth-section--reverse .auth-card {
+  order: 2;
+}
+
+.auth-main .auth-section--reverse .auth-panel {
+  order: 1;
+}
+
+.auth-main .auth-card {
+  padding: 1.35rem;
+  display: grid;
+  gap: 0.88rem;
+  align-content: start;
+}
+
+.auth-main .auth-card__title {
+  font-size: clamp(2rem, 3.7vw, 2.95rem);
+}
+
+.auth-main .auth-card__description {
+  max-width: 58ch;
+}
+
+.auth-main .auth-card__list {
+  list-style: none;
+  display: grid;
+  gap: 0.58rem;
+}
+
+.auth-main .auth-card__list li {
+  padding: 0.64rem 0.72rem;
+  border-radius: 0.68rem;
+  border: 1px solid rgba(165, 198, 255, 0.3);
+  background: rgba(20, 52, 106, 0.34);
+  color: #d6e6ff;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.auth-main .auth-card__list li::before {
+  content: '✓';
+  color: #8ebcff;
+  font-weight: 700;
+}
+
+.auth-main .auth-card__actions,
+.auth-main .auth-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.58rem;
+}
+
+.auth-main .auth-card__support {
+  color: #d0ddf8;
+}
+
+.auth-main .auth-panel {
+  padding: 1rem;
+  display: grid;
+  gap: 0.92rem;
+  align-content: start;
+}
+
+.auth-main .auth-panel__media {
+  min-height: 245px;
+}
+
+.auth-main .auth-panel__content {
+  display: grid;
+  gap: 0.7rem;
+}
+
+@media (max-width: 940px) {
+  .auth-main .auth-section {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-main .auth-section--reverse .auth-card,
+  .auth-main .auth-section--reverse .auth-panel {
+    order: unset;
+  }
+}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,5 @@
+import './auth.css';
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -286,92 +286,6 @@ p {
   padding: 2.25rem 0 4.8rem;
 }
 
-.auth-main {
-  width: 100%;
-  max-width: none;
-  margin: 0;
-  padding: 2.25rem 0 4.8rem;
-}
-
-.auth-section {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-  align-items: stretch;
-}
-
-.auth-section--reverse .auth-card {
-  order: 2;
-}
-
-.auth-section--reverse .auth-panel {
-  order: 1;
-}
-
-.auth-card {
-  padding: 1.35rem;
-  display: grid;
-  gap: 0.88rem;
-  align-content: start;
-}
-
-.auth-card__title {
-  font-size: clamp(2rem, 3.7vw, 2.95rem);
-}
-
-.auth-card__description {
-  max-width: 58ch;
-}
-
-.auth-card__list {
-  list-style: none;
-  display: grid;
-  gap: 0.58rem;
-}
-
-.auth-card__list li {
-  padding: 0.64rem 0.72rem;
-  border-radius: 0.68rem;
-  border: 1px solid rgba(165, 198, 255, 0.3);
-  background: rgba(20, 52, 106, 0.34);
-  color: #d6e6ff;
-  display: flex;
-  gap: 0.5rem;
-}
-
-.auth-card__list li::before {
-  content: '✓';
-  color: #8ebcff;
-  font-weight: 700;
-}
-
-.auth-card__actions,
-.auth-panel__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.58rem;
-}
-
-.auth-card__support {
-  color: #d0ddf8;
-}
-
-.auth-panel {
-  padding: 1rem;
-  display: grid;
-  gap: 0.92rem;
-  align-content: start;
-}
-
-.auth-panel__media {
-  min-height: 245px;
-}
-
-.auth-panel__content {
-  display: grid;
-  gap: 0.7rem;
-}
-
 .eyebrow {
   display: inline-flex;
   align-items: center;
@@ -839,7 +753,6 @@ p {
   }
 
   .hero,
-  .auth-section,
   .content-hero,
   .split-section,
   .feature-row,
@@ -858,9 +771,7 @@ p {
   }
 
   .feature-row--reverse .feature-row__copy,
-  .feature-row--reverse .media-card,
-  .auth-section--reverse .auth-card,
-  .auth-section--reverse .auth-panel {
+  .feature-row--reverse .media-card {
     order: unset;
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce global CSS bleed by moving authentication presentation styles out of `app/globals.css` and scope them to the auth route segment. 
- Ensure shared primitives (buttons, typography tokens) remain in globals so other pages are unaffected. 

### Description
- Moved auth-only style blocks (all `.auth-*` selectors and responsive auth rules) from `app/globals.css` into a dedicated `app/(auth)/auth.css` and prefixed rules with `.auth-main` to narrow selector scope. 
- Added `app/(auth)/layout.tsx` which imports `./auth.css` so auth styles only apply inside the auth route group. 
- Removed now-dead auth selectors and auth-specific responsive rules from `app/globals.css` while keeping shared primitives intact. 
- Adjusted responsive lists in `app/globals.css` to remove auth selectors that are no longer global. 

### Testing
- Ran `pnpm lint` and the lint pass completed successfully. 
- Ran `pnpm typecheck` (`tsc --noEmit`) and type checking passed. 
- Verified no `auth-*` classes are used outside `app/(auth)` using ripgrep and a targeted check, which returned no unexpected usages. 
- Attempted visual validation with a Playwright script that captured `/`, `/features`, `/about`, `/contact`, and `/sign-in`, but full visual parity verification was blocked because the development environment lacks the Clerk `secretKey` (pages returned 404), so visual diffs for non-auth pages could not be conclusively validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1050cf2d48327bed09fb4be57b546)