### PR TITLE
Fix PostCSS/Turbopack build error by closing @layer block in `app/globals.css`

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -807,3 +807,5 @@ p {
     grid-template-columns: 1fr;
   }
 }
+
+}


### PR DESCRIPTION
### Motivation
- Resolve a PostCSS/Turbopack build failure caused by an unclosed `@layer components` block in the global stylesheet which produced a `CssSyntaxError: Unclosed block` during `next build`.

### Description
- Add the missing closing brace at the end of `app/globals.css` to properly terminate the `@layer components` block, keeping the change minimal and scoped to the stylesheet only.

### Testing
- Ran `pnpm build`, which completes successfully with Next.js/Turbopack compiling and static pages generated without the previous PostCSS error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a14afcfc98832791bac4b2cc5215a2)