### PR TITLE
[WIP] [CAT-202] Enforce required asset roles before publish

### DIFF
--- a/lib/catalog/actions/create-wrap.ts
+++ b/lib/catalog/actions/create-wrap.ts
@@ -15,6 +15,7 @@ export async function createWrap(input: CreateWrapInput): Promise<WrapDTO> {
       description: parsed.description ?? null,
       price: parsed.price,
       installationMinutes: parsed.installationMinutes ?? null,
+      isHidden: true,
     },
     select: { id: true },
   });
@@ -25,7 +26,7 @@ export async function createWrap(input: CreateWrapInput): Promise<WrapDTO> {
       action: "wrap.created",
       resourceType: "Wrap",
       resourceId: created.id,
-      details: JSON.stringify({ name: parsed.name, priceInCents: parsed.price }),
+      details: JSON.stringify({ name: parsed.name, priceInCents: parsed.price, isHidden: true }),
       timestamp: new Date(),
     },
   });

--- a/lib/catalog/actions/update-wrap.ts
+++ b/lib/catalog/actions/update-wrap.ts
@@ -2,12 +2,53 @@
 
 import { requireOwnerOrPlatformAdmin } from "@/lib/authz/guards";
 import { prisma } from "@/lib/prisma";
-import { updateWrapSchema, type UpdateWrapInput, type WrapDTO } from "../types";
+import {
+  PUBLISH_REQUIRED_WRAP_IMAGE_KINDS,
+  updateWrapSchema,
+  type UpdateWrapInput,
+  type WrapDTO,
+} from "../types";
 import { getWrapById } from "../fetchers/get-wraps";
+import { assertWrapCanBePublished } from "../validators/publish-wrap";
 
 export async function updateWrap(wrapId: string, input: UpdateWrapInput): Promise<WrapDTO> {
   const session = await requireOwnerOrPlatformAdmin();
   const parsed = updateWrapSchema.parse(input);
+
+  const existing = await prisma.wrap.findFirst({
+    where: {
+      id: wrapId,
+      deletedAt: null,
+    },
+    select: {
+      id: true,
+      isHidden: true,
+    },
+  });
+
+  if (!existing) {
+    throw new Error("Forbidden: resource not found");
+  }
+
+  const isPublishing = existing.isHidden && parsed.isHidden === false;
+
+  if (isPublishing) {
+    const publishAssets = await prisma.wrapImage.findMany({
+      where: {
+        wrapId,
+        deletedAt: null,
+        kind: {
+          in: [...PUBLISH_REQUIRED_WRAP_IMAGE_KINDS],
+        },
+      },
+      select: {
+        kind: true,
+        isActive: true,
+      },
+    });
+
+    assertWrapCanBePublished(publishAssets);
+  }
 
   const data = Object.fromEntries(
     Object.entries(parsed).filter(([, value]) => value !== undefined),

--- a/lib/catalog/types.ts
+++ b/lib/catalog/types.ts
@@ -35,6 +35,13 @@ const wrapImageKindValues: [WrapImageKind, ...WrapImageKind[]] = [
   WrapImageKind.GALLERY,
 ];
 
+export const PUBLISH_REQUIRED_WRAP_IMAGE_KINDS = [
+  WrapImageKind.HERO,
+  WrapImageKind.VISUALIZER_TEXTURE,
+] as const;
+
+export type PublishRequiredWrapImageKind = (typeof PUBLISH_REQUIRED_WRAP_IMAGE_KINDS)[number];
+
 // ─── DTOs ─────────────────────────────────────────────────────────────────────
 
 export interface WrapImageDTO {

--- a/lib/catalog/validators/publish-wrap.test.ts
+++ b/lib/catalog/validators/publish-wrap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { assertWrapCanBePublished, getMissingRequiredAssetRolesForPublish } from "./publish-wrap";
+
+describe("getMissingRequiredAssetRolesForPublish", () => {
+  it("returns both required roles when no assets are present", () => {
+    expect(getMissingRequiredAssetRolesForPublish([])).toEqual(["hero", "visualizer_texture"]);
+  });
+
+  it("requires active roles and ignores inactive entries", () => {
+    expect(
+      getMissingRequiredAssetRolesForPublish([
+        { kind: "hero", isActive: false },
+        { kind: "visualizer_texture", isActive: true },
+      ]),
+    ).toEqual(["hero"]);
+  });
+
+  it("returns empty when required active roles exist", () => {
+    expect(
+      getMissingRequiredAssetRolesForPublish([
+        { kind: "hero", isActive: true },
+        { kind: "visualizer_texture", isActive: true },
+        { kind: "gallery", isActive: true },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("assertWrapCanBePublished", () => {
+  it("throws with missing role details", () => {
+    expect(() =>
+      assertWrapCanBePublished([
+        { kind: "hero", isActive: true },
+        { kind: "visualizer_texture", isActive: false },
+      ]),
+    ).toThrow("Cannot publish wrap. Missing active asset roles: visualizer_texture");
+  });
+
+  it("does not throw when publish prerequisites are met", () => {
+    expect(() =>
+      assertWrapCanBePublished([
+        { kind: "hero", isActive: true },
+        { kind: "visualizer_texture", isActive: true },
+      ]),
+    ).not.toThrow();
+  });
+});

--- a/lib/catalog/validators/publish-wrap.ts
+++ b/lib/catalog/validators/publish-wrap.ts
@@ -1,0 +1,24 @@
+import { PUBLISH_REQUIRED_WRAP_IMAGE_KINDS, type PublishRequiredWrapImageKind } from "../types";
+
+export interface WrapPublishAssetRoleSnapshot {
+  kind: string;
+  isActive: boolean;
+}
+
+export function getMissingRequiredAssetRolesForPublish(
+  images: WrapPublishAssetRoleSnapshot[],
+): PublishRequiredWrapImageKind[] {
+  const activeRoles = new Set(images.filter((image) => image.isActive).map((image) => image.kind));
+
+  return PUBLISH_REQUIRED_WRAP_IMAGE_KINDS.filter((kind) => !activeRoles.has(kind));
+}
+
+export function assertWrapCanBePublished(images: WrapPublishAssetRoleSnapshot[]): void {
+  const missingKinds = getMissingRequiredAssetRolesForPublish(images);
+
+  if (missingKinds.length === 0) {
+    return;
+  }
+
+  throw new Error(`Cannot publish wrap. Missing active asset roles: ${missingKinds.join(", ")}`);
+}


### PR DESCRIPTION
## Description
Enforces required wrap asset roles before allowing a wrap to be published.

## Related Issues
Closes #234

## Type of Change
- [x] Feature
- [x] Backend/API logic
- [x] Tests

## Changes Made
- Added required-role publish validator and tests.
- Enforced default hidden state for newly created wraps.
- Added publish transition guard in wrap update action.

## Testing
- pnpm exec vitest run lib/catalog/validators/publish-wrap.test.ts
- pnpm exec eslint lib/catalog/actions/create-wrap.ts lib/catalog/actions/update-wrap.ts lib/catalog/validators/publish-wrap.ts lib/catalog/validators/publish-wrap.test.ts
- pnpm exec prettier --check lib/catalog/actions/create-wrap.ts lib/catalog/actions/update-wrap.ts lib/catalog/types.ts lib/catalog/validators/publish-wrap.ts lib/catalog/validators/publish-wrap.test.ts

## Screenshots
N/A

## Security Checklist
- [x] No Prisma usage in app/** (except webhook routes)
- [x] Authz/ownership checks remain server-side
- [x] Input handling remains validated
- [x] No client-supplied scope trust introduced

## Code Quality Checklist
- [x] pnpm lint (targeted)
- [x] pnpm format:check (targeted)
- [ ] pnpm typecheck (blocked by existing repo baseline)
- [ ] pnpm prisma:validate (not run in this slice)
- [ ] pnpm build (not run in this slice)
- [ ] pnpm test (full suite not run)

## Additional Context
This PR is scoped to CAT-202 publish guard behavior.