### PR TITLE
[WIP] [QA-104] Replace legacy API-mock E2E tests with App Router flows

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -8,6 +8,7 @@
  */
 
 import { expect, test } from "@playwright/test";
+import { expectAuthRedirectWithContext } from "./helpers/auth-redirect";
 
 // ─── Public page accessibility ────────────────────────────────────────────────
 
@@ -64,16 +65,13 @@ test.describe("Protected routes", () => {
   for (const route of protectedRoutes) {
     test(`${route} redirects unauthenticated users to sign-in`, async ({ page }) => {
       await page.goto(route);
-      await page.waitForURL(
-        (url) =>
-          url.pathname.startsWith("/sign-in") ||
-          url.pathname === "/sign-in" ||
-          // Clerk sometimes uses its own hosted pages
-          url.hostname.includes("clerk"),
-      );
-      // Should end up on a sign-in page (Clerk hosted or local)
-      const currentUrl = page.url();
-      expect(currentUrl.includes("sign-in") || currentUrl.includes("clerk")).toBeTruthy();
+      await expectAuthRedirectWithContext(page, route);
     });
   }
+
+  test("preserves requested route context for redirects with query strings", async ({ page }) => {
+    const routeWithQuery = "/catalog?source=e2e&branch_context=1";
+    await page.goto(routeWithQuery);
+    await expectAuthRedirectWithContext(page, routeWithQuery);
+  });
 });

--- a/e2e/catalog-to-payment.spec.ts
+++ b/e2e/catalog-to-payment.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { expectAuthRedirectWithContext } from "./helpers/auth-redirect";
 
 test.describe("Domain Journey Smoke", () => {
   test("public homepage renders", async ({ page }) => {
@@ -9,10 +10,7 @@ test.describe("Domain Journey Smoke", () => {
   for (const route of ["/catalog", "/visualizer", "/scheduling", "/billing"]) {
     test(`${route} redirects anonymous users to sign-in`, async ({ page }) => {
       await page.goto(route);
-      await page.waitForURL(
-        (url) => url.pathname.startsWith("/sign-in") || url.hostname.includes("clerk"),
-      );
-      expect(page.url().includes("sign-in") || page.url().includes("clerk")).toBeTruthy();
+      await expectAuthRedirectWithContext(page, route);
     });
   }
 

--- a/e2e/helpers/auth-redirect.ts
+++ b/e2e/helpers/auth-redirect.ts
@@ -1,0 +1,86 @@
+import { expect, type Page } from "@playwright/test";
+
+const hostedAuthQueryKeys = [
+  "redirect_url",
+  "redirectUrl",
+  "after_sign_in_url",
+  "afterSignInUrl",
+  "return_back_url",
+  "returnBackUrl",
+];
+
+function includesRequestedPath(rawValue: string | null, requestedPath: string): boolean {
+  if (!rawValue) {
+    return false;
+  }
+
+  const candidates = new Set<string>([rawValue]);
+  try {
+    candidates.add(decodeURIComponent(rawValue));
+  } catch {
+    // Ignore malformed values and continue matching raw payload.
+  }
+
+  for (const value of candidates) {
+    if (value === requestedPath || value.includes(requestedPath)) {
+      return true;
+    }
+
+    if (value.startsWith("/")) {
+      continue;
+    }
+
+    try {
+      const parsed = new URL(value);
+      if (`${parsed.pathname}${parsed.search}` === requestedPath) {
+        return true;
+      }
+      for (const key of hostedAuthQueryKeys) {
+        if (includesRequestedPath(parsed.searchParams.get(key), requestedPath)) {
+          return true;
+        }
+      }
+    } catch {
+      // Ignore non-URL values.
+    }
+  }
+
+  return false;
+}
+
+export async function expectAuthRedirectWithContext(
+  page: Page,
+  requestedPath: string,
+): Promise<void> {
+  await page.waitForURL(
+    (url) => url.pathname.startsWith("/sign-in") || url.hostname.includes("clerk"),
+  );
+
+  const redirectedUrl = new URL(page.url());
+
+  if (redirectedUrl.pathname.startsWith("/sign-in")) {
+    const redirectTarget = redirectedUrl.searchParams.get("redirect_url");
+    expect(redirectTarget).not.toBeNull();
+
+    if (!redirectTarget) {
+      return;
+    }
+
+    const expected = new URL(requestedPath, "https://local.test");
+    const received = new URL(redirectTarget, "https://local.test");
+
+    expect(received.pathname).toBe(expected.pathname);
+    expect([...received.searchParams.entries()].sort()).toEqual(
+      [...expected.searchParams.entries()].sort(),
+    );
+    return;
+  }
+
+  expect(redirectedUrl.hostname).toContain("clerk");
+
+  const hasRequestedPathContext = hostedAuthQueryKeys.some((key) =>
+    includesRequestedPath(redirectedUrl.searchParams.get(key), requestedPath),
+  );
+
+  expect(hasRequestedPathContext).toBeTruthy();
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,6 @@ const webServer = process.env.BASE_URL
 
 export default defineConfig({
   testDir: "./e2e",
-  testIgnore: ["**/fixtures/**"],
   /* Maximum time one test can run */
   timeout: 30_000,
   /* Fail CI fast on first failure */


### PR DESCRIPTION
## Description
Replaces legacy redirect assertions in E2E auth journeys with App Router/server-action aligned redirect-context checks.

## Related Issues
Closes #223

## Type of Change
- [x] Tests

## Changes Made
- Added shared auth redirect context helper for local and hosted Clerk flows.
- Updated protected-route redirect assertions in auth and domain-journey specs.
- Removed stale Playwright legacy fixture ignore.

## Testing
- pnpm exec eslint e2e/auth.spec.ts e2e/catalog-to-payment.spec.ts e2e/helpers/auth-redirect.ts playwright.config.ts
- pnpm test:e2e e2e/auth.spec.ts e2e/catalog-to-payment.spec.ts --project=chromium --reporter=line

## Screenshots
N/A

## Security Checklist
- [x] No Prisma in app/**
- [x] Server-side authz model unchanged
- [x] No client scope trust introduced

## Code Quality Checklist
- [x] pnpm lint (targeted)
- [ ] pnpm typecheck (not run in this slice)
- [ ] pnpm prisma:validate (not run in this slice)
- [ ] pnpm build (not run in this slice)
- [ ] pnpm test (full suite not run)

## Additional Context
Focused E2E modernization for auth redirect behavior.